### PR TITLE
Add database migration init container with table creation scripts

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -14,6 +14,75 @@ spec:
       labels:
         {{- include "backend.selectorLabels" . | nindent 8 }}
     spec:
+      initContainers:
+        - name: db-migration
+          image: postgres:15
+          env:
+            - name: PGHOST
+              value: {{ .Values.env.DB_HOST }}
+            - name: PGPORT
+              value: {{ .Values.env.DB_PORT }}
+            - name: PGDATABASE
+              value: {{ .Values.env.DB_NAME }}
+            - name: PGUSER
+              value: {{ .Values.env.DB_USER }}
+            - name: PGPASSWORD
+              value: {{ .Values.env.DB_PASSWORD }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              # Create tables
+              psql << 'EOF'
+              CREATE TABLE IF NOT EXISTS users (
+                  id SERIAL PRIMARY KEY,
+                  name VARCHAR(255) NOT NULL,
+                  password VARCHAR(255) NOT NULL,
+                  email VARCHAR(255) NOT NULL,
+                  is_admin BOOLEAN DEFAULT FALSE,
+                  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+              );
+              
+              CREATE TABLE IF NOT EXISTS blogs (
+                  id SERIAL PRIMARY KEY,
+                  title VARCHAR(255) NOT NULL,
+                  content TEXT NOT NULL,
+                  user_id INT NOT NULL REFERENCES users(id),
+                  path VARCHAR(255) NOT NULL,
+                  modified_at TIMESTAMP,
+                  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+              );
+              
+              CREATE TABLE IF NOT EXISTS products (
+                  id SERIAL PRIMARY KEY,
+                  name VARCHAR(255) NOT NULL,
+                  price DECIMAL(10, 2) NOT NULL,
+                  image_url TEXT NOT NULL,
+                  is_available BOOLEAN DEFAULT TRUE,
+                  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+              );
+              
+              CREATE TABLE IF NOT EXISTS orders (
+                  id SERIAL PRIMARY KEY,
+                  address TEXT NOT NULL,
+                  user_id INT NOT NULL REFERENCES users(id),
+                  is_completed BOOLEAN DEFAULT FALSE,
+                  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+              );
+              
+              CREATE TABLE IF NOT EXISTS order_products (
+                  id SERIAL PRIMARY KEY,
+                  order_id INT NOT NULL REFERENCES orders(id),
+                  product_id INT NOT NULL REFERENCES products(id),
+                  quantity INT NOT NULL,
+                  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+              );
+              
+              -- Insert admin user (password is 'admin123' hashed)
+              INSERT INTO users (name, password, email, is_admin) 
+              VALUES ('admin', '$2a$14$example_hash_here', 'admin@test.com', true) 
+              ON CONFLICT (name) DO NOTHING;
+              EOF
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Introduce an init container for database migrations that creates necessary tables and inserts an admin user upon deployment.