### PR TITLE
fix: improve ownership association and fix authorization for tenant owners

### DIFF
--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -40,11 +40,26 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	tenant, _ := r.Context().Value(TenantContextKey).(db.Tenant)
+	
+	role := "customer"
+	tenantID := uuid.NullUUID{}
+	
+	if tenant.ID != uuid.Nil {
+		tenantID = uuid.NullUUID{UUID: tenant.ID, Valid: true}
+		
+		// If tenant has no owners, first registrant becomes farmer_admin
+		owners, err := s.db.ListTenantOwners(r.Context(), tenant.ID)
+		if err == nil && len(owners) == 0 {
+			role = "farmer_admin"
+		}
+	}
+
 	arg := db.CreateUserParams{
-		TenantID:     uuid.NullUUID{},
+		TenantID:     tenantID,
 		Email:        req.Email,
 		PasswordHash: string(hashedPassword),
-		Role:         "customer",
+		Role:         role,
 	}
 
 	user, err := s.db.CreateUser(r.Context(), arg)
@@ -55,6 +70,14 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		}
 		s.errorResponse(w, r, http.StatusInternalServerError, "Failed to create user")
 		return
+	}
+
+	// If they became farmer_admin, also add to tenant_owners table
+	if role == "farmer_admin" && tenant.ID != uuid.Nil {
+		_ = s.db.AddTenantOwner(r.Context(), db.AddTenantOwnerParams{
+			TenantID: tenant.ID,
+			UserID:   user.ID,
+		})
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -53,13 +53,14 @@ func (s *Server) Routes() http.Handler {
 	r.Route("/api/v1", func(r chi.Router) {
 		// --- Public Routes ---
 		r.Post("/auth/login", s.handleLogin)
-		r.Post("/auth/register", s.handleRegister)
 		r.Get("/tenants", s.handleListTenants)
 		r.Get("/tenants/{slug}", s.handleGetTenant) // Moved out of middleware
+		r.Get("/tenants/{id}/owners", s.handleListTenantOwners)
 		r.Get("/tenants/categories", s.handleListTenantCategories)
 		
 		r.Group(func(r chi.Router) {
 			r.Use(s.TenantMiddleware)
+			r.Post("/auth/register", s.handleRegister)
 			r.Get("/products", s.handleListProducts)
 			r.Get("/categories", s.handleListCategories)
 			r.Get("/blogs", s.handleListBlogs)
@@ -98,7 +99,6 @@ func (s *Server) Routes() http.Handler {
 			r.Put("/tenants/{id}/owner", s.handleSetTenantOwner)
 			r.Post("/tenants/{id}/owners", s.handleAddTenantOwner)
 			r.Delete("/tenants/{id}/owners/{userID}", s.handleRemoveTenantOwner)
-			r.Get("/tenants/{id}/owners", s.handleListTenantOwners)
 			r.Delete("/tenants/{id}", s.handleDeleteTenant)
 			r.Get("/users", s.handleListUsers)
 		})

--- a/internal/api/tenant_handlers.go
+++ b/internal/api/tenant_handlers.go
@@ -226,12 +226,21 @@ func (s *Server) handleSetTenantOwner(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Also add to tenant_owners table for compatibility
+	// Also add to tenant_owners table for compatibility and promote role
 	if ownerID.Valid {
 		_ = s.db.AddTenantOwner(r.Context(), db.AddTenantOwnerParams{
 			TenantID: id,
 			UserID:   ownerID.UUID,
 		})
+		
+		// Promote user to farmer_admin if they aren't platform_admin
+		u, err := s.db.GetUserByID(r.Context(), ownerID.UUID)
+		if err == nil && u.Role == "customer" {
+			_, _ = s.db.UpdateUserRole(r.Context(), db.UpdateUserRoleParams{
+				ID:   ownerID.UUID,
+				Role: "farmer_admin",
+			})
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -267,6 +276,15 @@ func (s *Server) handleAddTenantOwner(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.errorResponse(w, r, http.StatusInternalServerError, "Failed to add owner")
 		return
+	}
+	
+	// Promote user to farmer_admin if they aren't platform_admin
+	u, err := s.db.GetUserByID(r.Context(), userID)
+	if err == nil && u.Role == "customer" {
+		_, _ = s.db.UpdateUserRole(r.Context(), db.UpdateUserRoleParams{
+			ID:   userID,
+			Role: "farmer_admin",
+		})
 	}
 
 	w.WriteHeader(http.StatusCreated)


### PR DESCRIPTION
This PR fixes the issue where shop owners were unable to manage their shops. 

Key changes:
- Moved `/tenants/{id}/owners` to a public route so frontend can verify ownership.
- Updated `handleRegister` to associate users with the current tenant and auto-assign `farmer_admin` to the first registrant.
- Updated `handleSetTenantOwner` and `handleAddTenantOwner` to automatically promote users to `farmer_admin` role.
- Ensured registration on a tenant page correctly sets the `tenant_id`.