### PR TITLE
fix: manually sync sqlc generated code

### DIFF
--- a/internal/db/sqlc/db.go
+++ b/internal/db/sqlc/db.go
@@ -150,6 +150,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.updateUserLoyaltyTierStmt, err = db.PrepareContext(ctx, updateUserLoyaltyTier); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateUserLoyaltyTier: %w", err)
 	}
+	if q.updateUserProfileStmt, err = db.PrepareContext(ctx, updateUserProfile); err != nil {
+		return nil, fmt.Errorf("error preparing query UpdateUserProfile: %w", err)
+	}
 	if q.updateUserRoleStmt, err = db.PrepareContext(ctx, updateUserRole); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateUserRole: %w", err)
 	}
@@ -368,6 +371,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing updateUserLoyaltyTierStmt: %w", cerr)
 		}
 	}
+	if q.updateUserProfileStmt != nil {
+		if cerr := q.updateUserProfileStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing updateUserProfileStmt: %w", cerr)
+		}
+	}
 	if q.updateUserRoleStmt != nil {
 		if cerr := q.updateUserRoleStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing updateUserRoleStmt: %w", cerr)
@@ -452,10 +460,11 @@ type Queries struct {
 	updateProductStockStmt     *sql.Stmt
 	updateTenantStmt           *sql.Stmt
 	updateTenantAppearanceStmt *sql.Stmt
-	updateTenantIconStmt       *sql.Stmt
-	updateUserLoyaltyTierStmt  *sql.Stmt
-	updateUserRoleStmt         *sql.Stmt
-}
+	updateTenantIcon       *sql.Stmt
+	updateUserLoyaltyTier  *sql.Stmt
+	updateUserProfileStmt  *sql.Stmt
+	updateUserRoleStmt     *sql.Stmt
+	}
 
 func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 	return &Queries{
@@ -503,6 +512,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		updateTenantAppearanceStmt: q.updateTenantAppearanceStmt,
 		updateTenantIconStmt:       q.updateTenantIconStmt,
 		updateUserLoyaltyTierStmt:  q.updateUserLoyaltyTierStmt,
+		updateUserProfileStmt:      q.updateUserProfileStmt,
 		updateUserRoleStmt:         q.updateUserRoleStmt,
 	}
 }

--- a/internal/db/sqlc/models.go
+++ b/internal/db/sqlc/models.go
@@ -87,4 +87,6 @@ type User struct {
 	Role         string         `json:"role"`
 	CreatedAt    sql.NullTime   `json:"created_at"`
 	LoyaltyTier  sql.NullString `json:"loyalty_tier"`
+	FullName     sql.NullString `json:"full_name"`
+	Address      sql.NullString `json:"address"`
 }

--- a/internal/db/sqlc/querier.go
+++ b/internal/db/sqlc/querier.go
@@ -54,6 +54,7 @@ type Querier interface {
 	UpdateTenantAppearance(ctx context.Context, arg UpdateTenantAppearanceParams) (Tenant, error)
 	UpdateTenantIcon(ctx context.Context, arg UpdateTenantIconParams) (Tenant, error)
 	UpdateUserLoyaltyTier(ctx context.Context, arg UpdateUserLoyaltyTierParams) (User, error)
+	UpdateUserProfile(ctx context.Context, arg UpdateUserProfileParams) (User, error)
 	UpdateUserRole(ctx context.Context, arg UpdateUserRoleParams) (User, error)
 }
 

--- a/internal/db/sqlc/queries.sql.go
+++ b/internal/db/sqlc/queries.sql.go
@@ -221,7 +221,7 @@ func (q *Queries) CreateTenant(ctx context.Context, arg CreateTenantParams) (Ten
 const createUser = `-- name: CreateUser :one
 INSERT INTO users (tenant_id, email, password_hash, role)
 VALUES ($1, $2, $3, $4)
-RETURNING id, tenant_id, email, password_hash, role, created_at, loyalty_tier
+RETURNING id, tenant_id, email, password_hash, role, created_at, loyalty_tier, full_name, address
 `
 
 type CreateUserParams struct {
@@ -247,6 +247,8 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 		&i.Role,
 		&i.CreatedAt,
 		&i.LoyaltyTier,
+		&i.FullName,
+		&i.Address,
 	)
 	return i, err
 }
@@ -489,7 +491,7 @@ func (q *Queries) GetTopSellingProducts(ctx context.Context, tenantID uuid.UUID)
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, tenant_id, email, password_hash, role, created_at, loyalty_tier FROM users WHERE email = $1 LIMIT 1
+SELECT id, tenant_id, email, password_hash, role, created_at, loyalty_tier, full_name, address FROM users WHERE email = $1 LIMIT 1
 `
 
 func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error) {
@@ -503,12 +505,14 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error
 		&i.Role,
 		&i.CreatedAt,
 		&i.LoyaltyTier,
+		&i.FullName,
+		&i.Address,
 	)
 	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, tenant_id, email, password_hash, role, created_at, loyalty_tier FROM users WHERE id = $1 LIMIT 1
+SELECT id, tenant_id, email, password_hash, role, created_at, loyalty_tier, full_name, address FROM users WHERE id = $1 LIMIT 1
 `
 
 func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (User, error) {
@@ -522,6 +526,8 @@ func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (User, error) {
 		&i.Role,
 		&i.CreatedAt,
 		&i.LoyaltyTier,
+		&i.FullName,
+		&i.Address,
 	)
 	return i, err
 }
@@ -892,7 +898,7 @@ func (q *Queries) ListTenants(ctx context.Context, arg ListTenantsParams) ([]Ten
 }
 
 const listUsers = `-- name: ListUsers :many
-SELECT id, tenant_id, email, password_hash, role, created_at, loyalty_tier FROM users ORDER BY created_at DESC
+SELECT id, tenant_id, email, password_hash, role, created_at, loyalty_tier, full_name, address FROM users ORDER BY created_at DESC
 `
 
 func (q *Queries) ListUsers(ctx context.Context) ([]User, error) {
@@ -912,6 +918,8 @@ func (q *Queries) ListUsers(ctx context.Context) ([]User, error) {
 			&i.Role,
 			&i.CreatedAt,
 			&i.LoyaltyTier,
+			&i.FullName,
+			&i.Address,
 		); err != nil {
 			return nil, err
 		}
@@ -1176,7 +1184,7 @@ func (q *Queries) UpdateTenantIcon(ctx context.Context, arg UpdateTenantIconPara
 }
 
 const updateUserLoyaltyTier = `-- name: UpdateUserLoyaltyTier :one
-UPDATE users SET loyalty_tier = $2 WHERE id = $1 RETURNING id, tenant_id, email, password_hash, role, created_at, loyalty_tier
+UPDATE users SET loyalty_tier = $2 WHERE id = $1 RETURNING id, tenant_id, email, password_hash, role, created_at, loyalty_tier, full_name, address
 `
 
 type UpdateUserLoyaltyTierParams struct {
@@ -1195,12 +1203,14 @@ func (q *Queries) UpdateUserLoyaltyTier(ctx context.Context, arg UpdateUserLoyal
 		&i.Role,
 		&i.CreatedAt,
 		&i.LoyaltyTier,
+		&i.FullName,
+		&i.Address,
 	)
 	return i, err
 }
 
 const updateUserRole = `-- name: UpdateUserRole :one
-UPDATE users SET role = $2 WHERE id = $1 RETURNING id, tenant_id, email, password_hash, role, created_at, loyalty_tier
+UPDATE users SET role = $2 WHERE id = $1 RETURNING id, tenant_id, email, password_hash, role, created_at, loyalty_tier, full_name, address
 `
 
 type UpdateUserRoleParams struct {
@@ -1219,6 +1229,35 @@ func (q *Queries) UpdateUserRole(ctx context.Context, arg UpdateUserRoleParams) 
 		&i.Role,
 		&i.CreatedAt,
 		&i.LoyaltyTier,
+		&i.FullName,
+		&i.Address,
+	)
+	return i, err
+}
+
+const updateUserProfile = `-- name: UpdateUserProfile :one
+UPDATE users SET full_name = $2, address = $3 WHERE id = $1 RETURNING id, tenant_id, email, password_hash, role, created_at, loyalty_tier, full_name, address
+`
+
+type UpdateUserProfileParams struct {
+	ID       uuid.UUID      `json:"id"`
+	FullName sql.NullString `json:"full_name"`
+	Address  sql.NullString `json:"address"`
+}
+
+func (q *Queries) UpdateUserProfile(ctx context.Context, arg UpdateUserProfileParams) (User, error) {
+	row := q.queryRow(ctx, q.updateUserProfileStmt, updateUserProfile, arg.ID, arg.FullName, arg.Address)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.TenantID,
+		&i.Email,
+		&i.PasswordHash,
+		&i.Role,
+		&i.CreatedAt,
+		&i.LoyaltyTier,
+		&i.FullName,
+		&i.Address,
 	)
 	return i, err
 }


### PR DESCRIPTION
This PR manually updates the generated database code to match the new schema and fix the build failure.