### PR TITLE
fix: register product and blog management endpoints under tenant group

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -119,6 +119,16 @@ func (s *Server) Routes() http.Handler {
 			r.Put("/orders/{id}/status", s.handleUpdateOrderStatus)
 			r.Get("/analytics/revenue", s.handleGetRevenueAnalytics)
 			r.Get("/analytics/top-products", s.handleGetTopProducts)
+
+			// Product management
+			r.Post("/products", s.handleAddProduct)
+			r.Put("/products/{id}", s.handleUpdateProduct)
+			r.Delete("/products/{id}", s.handleDeleteProduct)
+
+			// Blog management
+			r.Post("/blogs", s.handleCreateBlog)
+			r.Put("/blogs/{id}", s.handleUpdateBlog)
+			r.Delete("/blogs/{id}", s.handleDeleteBlog)
 		})
 	})
 


### PR DESCRIPTION
This PR registers the missing POST, PUT, and DELETE routes for products and blogs in the Chi router under the tenant management routing group. This fixes the 405 Method Not Allowed error when modifying inventory items or blog entries in the admin dashboard.