### PR TITLE
fix: address validation, order history and loyalty counter bugs

### DIFF
--- a/internal/api/order_handlers.go
+++ b/internal/api/order_handlers.go
@@ -30,6 +30,20 @@ func (s *Server) handlePlaceOrder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Verify user has filled in their address in their profile
+	userProfile, err := s.db.GetUserByID(r.Context(), userID)
+	if err != nil {
+		s.errorResponse(w, r, http.StatusInternalServerError, "Failed to retrieve user profile")
+		return
+	}
+
+	if !userProfile.Street.Valid || userProfile.Street.String == "" ||
+		!userProfile.ZipCode.Valid || userProfile.ZipCode.String == "" ||
+		!userProfile.City.Valid || userProfile.City.String == "" {
+		s.errorResponse(w, r, http.StatusBadRequest, "Please set your full delivery address in your profile before placing an order")
+		return
+	}
+
 	var req placeOrderRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		s.errorResponse(w, r, http.StatusBadRequest, "Invalid input")
@@ -153,6 +167,29 @@ func (s *Server) handlePlaceOrder(w http.ResponseWriter, r *http.Request) {
 	if err := tx.Commit(); err != nil {
 		s.errorResponse(w, r, http.StatusInternalServerError, "Failed to commit transaction")
 		return
+	}
+
+	// Recalculate and update user loyalty tier based on number of orders placed
+	userOrders, err := s.db.ListOrdersByUser(r.Context(), userID)
+	if err == nil {
+		orderCount := len(userOrders)
+		var newTier string
+		if orderCount >= 20 {
+			newTier = "Harvest Elite"
+		} else if orderCount >= 10 {
+			newTier = "Harvester"
+		} else if orderCount >= 3 {
+			newTier = "Sprout"
+		} else {
+			newTier = "Seedling"
+		}
+
+		if userProfile.LoyaltyTier.String != newTier {
+			_, _ = s.db.UpdateUserLoyaltyTier(r.Context(), db.UpdateUserLoyaltyTierParams{
+				ID:          userID,
+				LoyaltyTier: sql.NullString{String: newTier, Valid: true},
+			})
+		}
 	}
 
 	// Post-commit: Send notifications (non-blocking or at least outside tx)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -74,14 +74,14 @@ func (s *Server) Routes() http.Handler {
 			r.Get("/auth/profile", s.handleGetProfile)
 			r.Put("/auth/profile", s.handleUpdateProfile)
 			r.Post("/upload", s.handleUpload)
+			r.Get("/orders/my", s.handleListMyOrders)
+			r.Get("/orders/{id}", s.handleGetOrderDetails)
+			r.Get("/loyalty", s.handleGetUserLoyalty)
 			
 			r.Group(func(r chi.Router) {
 				r.Use(s.TenantMiddleware)
 				r.Post("/orders", s.handlePlaceOrder)
-				r.Get("/orders/my", s.handleListMyOrders)
-				r.Get("/orders/{id}", s.handleGetOrderDetails)
 				r.Post("/products/{id}/reviews", s.handleCreateReview)
-				r.Get("/loyalty", s.handleGetUserLoyalty)
 				r.Get("/categories", s.handleListCategories)
 			})
 		})


### PR DESCRIPTION
This PR moves user-centric order and loyalty endpoints out of the TenantMiddleware routing group to avoid 400 Bad Request errors when tenant context is missing. It also adds backend validation ensuring users have set their street, zip code, and city before checking out, and automatically recalculates and updates the user's loyalty tier upon successful order placement.