### PR TITLE
fix: update category/specialty inside UpdateTenantAppearance query and handler

### DIFF
--- a/internal/api/tenant_handlers.go
+++ b/internal/api/tenant_handlers.go
@@ -168,6 +168,7 @@ func (s *Server) handleUpdateTenantAppearance(w http.ResponseWriter, r *http.Req
 	var req struct {
 		CoverUrl    string `json:"cover_url"`
 		Description string `json:"description"`
+		Category    string `json:"category"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -179,6 +180,7 @@ func (s *Server) handleUpdateTenantAppearance(w http.ResponseWriter, r *http.Req
 		ID:          tenant.ID,
 		CoverUrl:    sql.NullString{String: req.CoverUrl, Valid: req.CoverUrl != ""},
 		Description: sql.NullString{String: req.Description, Valid: req.Description != ""},
+		Category:    sql.NullString{String: req.Category, Valid: req.Category != ""},
 	}
 
 	updatedTenant, err := s.db.UpdateTenantAppearance(r.Context(), arg)

--- a/internal/db/sqlc/queries.sql.go
+++ b/internal/db/sqlc/queries.sql.go
@@ -1162,17 +1162,23 @@ func (q *Queries) UpdateTenant(ctx context.Context, arg UpdateTenantParams) (Ten
 }
 
 const updateTenantAppearance = `-- name: UpdateTenantAppearance :one
-UPDATE tenants SET cover_url = $2, description = $3 WHERE id = $1 RETURNING id, name, slug, created_at, icon_url, cover_url, description, owner_id, category
+UPDATE tenants SET cover_url = $2, description = $3, category = $4 WHERE id = $1 RETURNING id, name, slug, created_at, icon_url, cover_url, description, owner_id, category
 `
 
 type UpdateTenantAppearanceParams struct {
 	ID          uuid.UUID      `json:"id"`
 	CoverUrl    sql.NullString `json:"cover_url"`
 	Description sql.NullString `json:"description"`
+	Category    sql.NullString `json:"category"`
 }
 
 func (q *Queries) UpdateTenantAppearance(ctx context.Context, arg UpdateTenantAppearanceParams) (Tenant, error) {
-	row := q.queryRow(ctx, q.updateTenantAppearanceStmt, updateTenantAppearance, arg.ID, arg.CoverUrl, arg.Description)
+	row := q.queryRow(ctx, q.updateTenantAppearanceStmt, updateTenantAppearance,
+		arg.ID,
+		arg.CoverUrl,
+		arg.Description,
+		arg.Category,
+	)
 	var i Tenant
 	err := row.Scan(
 		&i.ID,

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -181,7 +181,7 @@ SELECT EXISTS (
 );
 
 -- name: UpdateTenantAppearance :one
-UPDATE tenants SET cover_url = $2, description = $3 WHERE id = $1 RETURNING *;
+UPDATE tenants SET cover_url = $2, description = $3, category = $4 WHERE id = $1 RETURNING *;
 
 -- name: GetUserByID :one
 SELECT * FROM users WHERE id = $1 LIMIT 1;


### PR DESCRIPTION
This PR updates the UpdateTenantAppearance query in queries.sql and the handleUpdateTenantAppearance handler in tenant_handlers.go to properly include the category field. This allows the Farm Specialty/Category to be saved correctly in the database when updating storefront appearance from the workbench.