### PR TITLE
fix: remove duplicate categories route from authenticated group

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -82,7 +82,6 @@ func (s *Server) Routes() http.Handler {
 				r.Use(s.TenantMiddleware)
 				r.Post("/orders", s.handlePlaceOrder)
 				r.Post("/products/{id}/reviews", s.handleCreateReview)
-				r.Get("/categories", s.handleListCategories)
 			})
 		})
 


### PR DESCRIPTION
Removes duplicate /categories route registration from authenticated group to ensure it always behaves as a public endpoint.