### PR TITLE
fix: correct Payrexx GET signature for gateway status check

### DIFF
--- a/internal/api/payment_handlers.go
+++ b/internal/api/payment_handlers.go
@@ -236,10 +236,9 @@ func (s *Server) checkPayrexxGatewayStatus(gatewayID int) (string, error) {
 	// API Endpoint
 	apiURL := fmt.Sprintf("https://api.payrexx.com/v1.0/Gateway/%d/?instance=%s", gatewayID, s.payrexxInstance)
 
-	// Signature needs to be computed on query string parameters excluding ApiSignature.
-	// The only query parameter we pass is "instance".
-	encodedParams := fmt.Sprintf("instance=%s", s.payrexxInstance)
-	signature := generatePayrexxSignature(encodedParams, s.payrexxAPISecret)
+	// Signature needs to be computed on query string parameters excluding ApiSignature and instance.
+	// Since there are no other query parameters, we sign an empty string.
+	signature := generatePayrexxSignature("", s.payrexxAPISecret)
 
 	// Create URL with query params
 	reqURL := fmt.Sprintf("%s&ApiSignature=%s", apiURL, url.QueryEscape(signature))

--- a/internal/api/public_routes_test.go
+++ b/internal/api/public_routes_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/M306/backend/internal/db/sqlc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublicRoutes(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Create a tenant
+	_, err := testQueries.CreateTenant(ctx, db.CreateTenantParams{
+		Name: "Test Farm",
+		Slug: "testfarm",
+	})
+	require.NoError(t, err)
+
+	server := NewServer(testQueries, testDB, &mockStorage{}, &MockEmailService{}, "secret", "", "")
+	r := server.Routes()
+
+	t.Run("GET products without token", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/api/v1/products", nil)
+		req.Header.Set("X-Tenant-Slug", "testfarm")
+		rr := httptest.NewRecorder()
+
+		r.ServeHTTP(rr, req)
+
+		// Expected to succeed (200 OK) since it's a public route
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	})
+
+	t.Run("GET blogs without token", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/api/v1/blogs", nil)
+		req.Header.Set("X-Tenant-Slug", "testfarm")
+		rr := httptest.NewRecorder()
+
+		r.ServeHTTP(rr, req)
+
+		// Expected to succeed (200 OK) since it's a public route
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	})
+
+	t.Run("GET products with invalid token", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/api/v1/products", nil)
+		req.Header.Set("X-Tenant-Slug", "testfarm")
+		req.Header.Set("Authorization", "Bearer invalidtoken")
+		rr := httptest.NewRecorder()
+
+		r.ServeHTTP(rr, req)
+
+		// Should still succeed (200 OK) because products route doesn't require authentication!
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	})
+}


### PR DESCRIPTION
Sign empty string instead of instance query param for parameterless GET requests